### PR TITLE
fix string obfuscator bug with rust

### DIFF
--- a/StringObfuscator/StringObfuscator.cpp
+++ b/StringObfuscator/StringObfuscator.cpp
@@ -89,12 +89,12 @@ Function *createDecodeStubFunc(Module &M, vector<GlobalString*> &GlobalStrings, 
 // }
 Function *createDecodeFunc(Module &M){
 	auto &Ctx = M.getContext();
-	FunctionCallee barcallee = M.getOrInsertFunction("decode", 
+	FunctionCallee DecodeFuncCallee = M.getOrInsertFunction("decode", 
 	/*ret*/			Type::getVoidTy(Ctx),
  /*args*/		Type::getInt8PtrTy(Ctx, 8),
  				Type::getInt32Ty(Ctx));
 
-	Function *DecodeFunc = cast<Function>(barcallee.getCallee());
+	Function *DecodeFunc = cast<Function>(DecodeFuncCallee.getCallee());
 	DecodeFunc->setCallingConv(CallingConv::C);
 
 	// Name DecodeFunc arguments


### PR DESCRIPTION
Recently, I was learning llvm ir. I executed a program crash when using your example. In the rust, I found the final problem after debugging:
The rust string don't end with '\0'. rust considers an '\0' as a serious safety issue in the string.

```
StringRef StrVal = CDA->getAsString();
const char *Data = StrVal.begin();
const int Size = StrVal.size();
```

StrVal.size() don't include  '\0' in the rust.

```
char *EncodeString(const char* Data, unsigned int Length) {
	// Encode string
	char *NewData = (char*)malloc(Length);
	for(unsigned int i = 0; i < Length; i++){
		NewData[i] = Data[i] + 1;
	}

        return NewData;
}
```

Therefore, the encode don't include adding 1 to the  '\0.

```
0x4012f0 <decode>       mov    (%rdi),%al                                                                                                             
0x4012f2 <decode+2>     test   %al,%al                                                                                                                                  
0x4012f4 <decode+4>     je     0x40130e <decode+30>                                                                                                                          
0x4012f6 <decode+6>     inc    %rdi                                                                                                                                          
0x4012f9 <decode+9>     nopl   0x0(%rax)                                                                                                                                     
0x401300 <decode+16>    dec    %al                                                                                                                                           
0x401302 <decode+18>    mov    %al,-0x1(%rdi)                                                                                                                                   
0x401305 <decode+21>    movzbl (%rdi),%eax                                                                                                                                   
0x401308 <decode+24>    lea    0x1(%rdi),%rdi                                                                                                                               
0x40130c <decode+28>    jne    0x401300 <decode+16>                                                                                                                          
0x40130e <decode+30>    retq
```

The decode cannot obtain '\0', the loop can‘t break and access the invalid address.

Solution：
1. Save the length of the actual string
2. Extend the decode to pass the actual length

My compilation environment:
rustc 1.53.0-dev
LLVM (http://llvm.org/):
LLVM version 12.0.0-rust-dev
Optimized build.
Default target: x86_64-unknown-linux-gnu
